### PR TITLE
feat: use local timezone to check file rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ http://localhost:3000/#access_token=<access_token>&scope=chat%3Aread+chat%3Aedit
 ```
 
 Create a .env file at the root of this project and copy the `<access_token>`
-from the URL string. This should look as follows:
+from the URL string. In addition, add in the `<channel>` where the bot should
+send messages. This should look as follows:
 
 ```
 ACCESS_TOKEN=<access_token>
+CHANNEL=<channel>
 ```
 
 ## Running chatbot with poetry

--- a/chatbot.py
+++ b/chatbot.py
@@ -7,6 +7,7 @@ from focus import write_focus
 
 load_dotenv()
 _ACCESS_TOKEN = os.getenv("ACCESS_TOKEN")
+_CHANNEL = os.getenv("CHANNEL")
 
 
 class Bot(commands.Bot):
@@ -16,7 +17,7 @@ class Bot(commands.Bot):
         super().__init__(
             token=_ACCESS_TOKEN,
             prefix="!",
-            initial_channels=["bedtimebear_808"],
+            initial_channels=[_CHANNEL],
         )
 
     async def event_ready(self):
@@ -29,5 +30,5 @@ class Bot(commands.Bot):
         author = ctx.message.author.name
         message = ctx.message.content.replace("!focus ", "").strip()
         timestamp = ctx.message.timestamp
-        write_focus(author, message, timestamp)
+        write_focus(author, message, timestamp.astimezone())
         await ctx.send(f"{author} is focusing: {message}.")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-import asyncio
 from chatbot import Bot
+
 
 bot = Bot()
 bot.run()

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,22 +97,11 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "freezegun"
-version = "1.2.2"
-description = "Let your Python tests travel through time"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-python-dateutil = ">=2.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
 name = "frozenlist"
@@ -164,26 +153,15 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "2.5.3"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
-
-[[package]]
-name = "python-dateutil"
-version = "2.8.2"
-description = "Extensions to the standard Python datetime module"
-category = "dev"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.4)", "sphinx (>=5.3)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
 
 [[package]]
 name = "python-dotenv"
@@ -197,14 +175,6 @@ python-versions = ">=3.7"
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "dev"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -214,7 +184,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "twitchio"
-version = "2.4.0"
+version = "2.5.0"
 description = "An asynchronous Python IRC and API wrapper for Twitch."
 category = "main"
 optional = false
@@ -251,7 +221,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c6bc2983746328273fa27755f1e7adab2effeee463f7f2853b9afc5927d0a03b"
+content-hash = "edbe00bd7718a50b08ca5c08646afa38f76447f184865e4bc82fa931a53d7012"
 
 [metadata.files]
 aiohttp = []
@@ -268,7 +238,6 @@ black = []
 charset-normalizer = []
 click = []
 colorama = []
-freezegun = []
 frozenlist = []
 idna = []
 iso8601 = []
@@ -336,9 +305,7 @@ multidict = [
 mypy-extensions = []
 pathspec = []
 platformdirs = []
-python-dateutil = []
 python-dotenv = []
-six = []
 tomli = []
 twitchio = []
 typing-extensions = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ python-dotenv = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.10.0"
-freezegun = "^1.2.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,6 @@ multidict==6.0.2; python_version >= "3.7" \
     --hash=sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae \
     --hash=sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013
 python-dotenv==0.21.0; python_version >= "3.7"
-twitchio==2.4.0
+twitchio==2.5.0
 typing-extensions==4.4.0; python_version >= "3.7"
 yarl==1.8.1; python_version >= "3.7"


### PR DESCRIPTION
* Removed dep freezegun. It was easier to handle datetime without it because of timezone issues.
* Add in the time delta of the timezone when figuring out if we should rotate the file.
* Update the channel to be an .env value. This was previously hard coded to bedtimebear_808.

closes #8